### PR TITLE
[FEATURE] add FeatureToggle for languageHandling

### DIFF
--- a/Resources/Private/Language/extensionmanager.xlf
+++ b/Resources/Private/Language/extensionmanager.xlf
@@ -6,6 +6,9 @@
 			<trans-unit id="setPageTSconfig">
 				<source>Set PageTSconfig by default: If you are going to use this extension by default in this database then set this flag. In that case you don't need to set specific PageTSconfig for each page, which you have to do otherwise!</source>
 			</trans-unit>
+			<trans-unit id="patchFlexLanguageHandling">
+				<source>Enable the Patch for (re-)adding language handling inside flexforms: only required if one of your flexforms missed &lt;langDisable&gt;1&lt;/langDisable&gt;</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,2 +1,5 @@
   # cat=basic/enable; type=boolean; label=LLL:EXT:compatibility6/Resources/Private/Language/extensionmanager.xlf:setPageTSconfig
 setPageTSconfig = 1
+
+  # cat=basic/enable; type=boolean; label=LLL:EXT:compatibility6/Resources/Private/Language/extensionmanager.xlf:patchFlexLanguageHandling
+patchFlexLanguageHandling = 1

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -13,47 +13,49 @@ if (!$_EXTCONF || $_EXTCONF['setPageTSconfig']) {
 
 // Register language aware flex form handling in FormEngine
 // Register render elements
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1443361297] = [
-    'nodeName' => 'flex',
-    'priority' => 40,
-    'class' => \TYPO3\CMS\Compatibility6\Form\Container\FlexFormEntryContainer::class,
-];
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1443361298] = [
-    'nodeName' => 'flexFormNoTabsContainer',
-    'priority' => 40,
-    'class' => \TYPO3\CMS\Compatibility6\Form\Container\FlexFormNoTabsContainer::class,
-];
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1443361299] = [
-    'nodeName' => 'flexFormTabsContainer',
-    'priority' => 40,
-    'class' => \TYPO3\CMS\Compatibility6\Form\Container\FlexFormTabsContainer::class,
-];
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1443361300] = [
-    'nodeName' => 'flexFormElementContainer',
-    'priority' => 40,
-    'class' => \TYPO3\CMS\Compatibility6\Form\Container\FlexFormElementContainer::class,
-];
-// Unregister stock TcaFlexProcess data provider and substitute with own data provider at the same position
-unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord']
-    [\TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexProcess::class]
-);
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord']
-    [\TYPO3\CMS\Compatibility6\Form\FormDataProvider\TcaFlexProcess::class] = [
-        'depends' => [
-            \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexPrepare::class,
-        ]
+if (!$_EXTCONF || $_EXTCONF['patchFlexLanguageHandling']) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1443361297] = [
+        'nodeName' => 'flex',
+        'priority' => 40,
+        'class' => \TYPO3\CMS\Compatibility6\Form\Container\FlexFormEntryContainer::class,
     ];
-unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord']
-    [\TYPO3\CMS\Backend\Form\FormDataProvider\TcaRadioItems::class]['depends'][\TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexProcess::class]
-);
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord']
-    [\TYPO3\CMS\Backend\Form\FormDataProvider\TcaRadioItems::class]['depends'][]
-        = \TYPO3\CMS\Compatibility6\Form\FormDataProvider\TcaFlexProcess::class;
-// Register "XCLASS" of FlexFormTools for language parsing
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools::class]['className']
-    = TYPO3\CMS\Compatibility6\Configuration\FlexForm\FlexFormTools::class;
-// Language diff updating in flex
-$GLOBALS['TYPO3_CONF_VARS']['BE']['flexFormXMLincludeDiffBase'] = true;
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1443361298] = [
+        'nodeName' => 'flexFormNoTabsContainer',
+        'priority' => 40,
+        'class' => \TYPO3\CMS\Compatibility6\Form\Container\FlexFormNoTabsContainer::class,
+    ];
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1443361299] = [
+        'nodeName' => 'flexFormTabsContainer',
+        'priority' => 40,
+        'class' => \TYPO3\CMS\Compatibility6\Form\Container\FlexFormTabsContainer::class,
+    ];
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1443361300] = [
+        'nodeName' => 'flexFormElementContainer',
+        'priority' => 40,
+        'class' => \TYPO3\CMS\Compatibility6\Form\Container\FlexFormElementContainer::class,
+    ];
+    // Unregister stock TcaFlexProcess data provider and substitute with own data provider at the same position
+    unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord']
+        [\TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexProcess::class]
+    );
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord']
+        [\TYPO3\CMS\Compatibility6\Form\FormDataProvider\TcaFlexProcess::class] = [
+            'depends' => [
+                \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexPrepare::class,
+            ]
+    ];
+    unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord']
+        [\TYPO3\CMS\Backend\Form\FormDataProvider\TcaRadioItems::class]['depends'][\TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexProcess::class]
+    );
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord']
+        [\TYPO3\CMS\Backend\Form\FormDataProvider\TcaRadioItems::class]['depends'][]
+            = \TYPO3\CMS\Compatibility6\Form\FormDataProvider\TcaFlexProcess::class;
+    // Register "XCLASS" of FlexFormTools for language parsing
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools::class]['className']
+        = TYPO3\CMS\Compatibility6\Configuration\FlexForm\FlexFormTools::class;
+    // Language diff updating in flex
+    $GLOBALS['TYPO3_CONF_VARS']['BE']['flexFormXMLincludeDiffBase'] = true;
+}
 
 
 // TCA migration if TCA registration still happened in ext_tables.php


### PR DESCRIPTION
add a feature toggle to disable the patching of flexform
languagehandling

If you are not affected by the change mentioned below you can now
disable the corresponding patch in compatibility6

https://docs.typo3.org/typo3cms/extensions/core/7.6/Changelog/7.6/Deprecation-70138-FlexFormLanguageHandling.html