### PR TITLE
Support integer-type section definitions

### DIFF
--- a/Classes/Form/FormDataProvider/TcaFlexProcess.php
+++ b/Classes/Form/FormDataProvider/TcaFlexProcess.php
@@ -395,7 +395,7 @@ class TcaFlexProcess implements FormDataProviderInterface
                 $langSheetLevel = 'l' . $isoSheetLevel;
                 foreach ($dataStructureSheetElements as $dataStructureSheetElementName => $dataStructureSheetElementDefinition) {
                     if (isset($dataStructureSheetElementDefinition['type']) && $dataStructureSheetElementDefinition['type'] === 'array'
-                        && isset($dataStructureSheetElementDefinition['section']) && $dataStructureSheetElementDefinition['section'] === '1'
+                        && isset($dataStructureSheetElementDefinition['section']) && (string)$dataStructureSheetElementDefinition['section'] === '1'
                     ) {
                         // A section
 


### PR DESCRIPTION
The current code does only work with strings: `<section>1</section>`.
When using a correctly-typed `<section type="integer">1</section>` it fails.