### PR TITLE
[BUGFIX] Change storage_pid TCA to work with MySQL strict mode

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -8,6 +8,7 @@ $additionalColumns = array(
         'label' => 'LLL:EXT:compatibility6/Resources/Private/Language/locallang.xlf:storage_pid',
         'config' => array(
             'type' => 'group',
+            'default' => '0',
             'internal_type' => 'db',
             'allowed' => 'pages',
             'size' => '1',


### PR DESCRIPTION
Description is in this issue: https://github.com/FriendsOfTYPO3/compatibility6/issues/18